### PR TITLE
Add props as third argument to mapToState

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -58,7 +58,7 @@ export default function (mapToState, mapToComponent) {
                 onBeforeMount.apply(this, [props, state]);
             }
 
-            this.state = mapToState(getState(), state);
+            this.state = mapToState(getState(), state, props);
             componentState = this.state;
 
             if (mapToComponent) {


### PR DESCRIPTION
This provides access to the static component properties for selecting out the relevant state in the application state (via `getState`).